### PR TITLE
Mention live website in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # README
 
+https://keep-alive.com.ua/
+
 This README would normally document whatever steps are necessary to get the
 application up and running.
 


### PR DESCRIPTION
From the repository page it isn't clear at what URL the project is hosted. This pull request adds a link to https://keep-alive.com.ua/ in the README.

Correct me if that's not the domain.